### PR TITLE
quick readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="logo.svg" width="250" height="250">
+  <img src="readmeFiles/logo.svg" width="250" height="250">
 </p>
 
 # CPUDIFF


### PR DESCRIPTION
The CPUDiff logo is now correctly displayed in the README file.